### PR TITLE
Feature/commonentity/9

### DIFF
--- a/src/main/java/com/mindspace/backend/domain/board/entity/Board.java
+++ b/src/main/java/com/mindspace/backend/domain/board/entity/Board.java
@@ -1,6 +1,7 @@
 package com.mindspace.backend.domain.board.entity;
 
 import com.mindspace.backend.domain.board.dto.BoardRequestDto;
+import com.mindspace.backend.global.common.Timestamp;
 import lombok.*;
 
 import javax.persistence.*;
@@ -11,7 +12,7 @@ import javax.persistence.*;
 @Table(name="board")
 @Builder
 @AllArgsConstructor
-public class Board {
+public class Board extends Timestamp {
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
     @Column(name = "board_id")

--- a/src/main/java/com/mindspace/backend/domain/node/entity/Node.java
+++ b/src/main/java/com/mindspace/backend/domain/node/entity/Node.java
@@ -1,5 +1,6 @@
 package com.mindspace.backend.domain.node.entity;
 
+import com.mindspace.backend.global.common.Timestamp;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,7 +14,7 @@ import javax.persistence.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Table(name= "node")
-public class Node {
+public class Node extends Timestamp {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "node_id")

--- a/src/main/java/com/mindspace/backend/domain/user/entity/User.java
+++ b/src/main/java/com/mindspace/backend/domain/user/entity/User.java
@@ -28,4 +28,8 @@ public class User extends Timestamp {
 
     @Column(name = "nickname", nullable = false)
     private String nickname;
+
+    @Column(name = "is_active", nullable = false)
+    @Builder.Default
+    private boolean isActive = true; //기본 값으로 true 넣기
 }

--- a/src/main/java/com/mindspace/backend/domain/user/entity/User.java
+++ b/src/main/java/com/mindspace/backend/domain/user/entity/User.java
@@ -1,5 +1,6 @@
 package com.mindspace.backend.domain.user.entity;
 
+import com.mindspace.backend.global.common.Timestamp;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,11 +13,11 @@ import javax.persistence.*;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@Table(name = "member")
-public class User {
+@Table(name = "user")
+public class User extends Timestamp {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "member_id")
+    @Column(name = "user_id")
     private int id;
 
     @Column(name = "email", nullable = false)

--- a/src/main/java/com/mindspace/backend/global/common/Timestamp.java
+++ b/src/main/java/com/mindspace/backend/global/common/Timestamp.java
@@ -1,0 +1,21 @@
+package com.mindspace.backend.global.common;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass // JPA Entity 클래스들이 해당 추상 클래스를 상속할 경우 createAt, updatedAt 컬럼으로 인식
+@EntityListeners(AuditingEntityListener.class) // 해당 클래스에 Auditing 기능을 포함
+public class Timestamp {
+    @CreatedDate // Entity가 생성되어 저장될 때 시간 자동 저장
+    private LocalDateTime createAt;
+
+    @LastModifiedDate // Entity의 값을 변경할 때 시간 자동 저장
+    private LocalDateTime updatedAt;
+}


### PR DESCRIPTION
## Summary
모든 table에서 사용되는 timestamp 작성
isActive 필드 추가

## Description
- 모든 table에서 사용되는 timestamp 작성
- user 테이블에 isActive 필드 추가 
- TODO: 다른 테이블 작업 완료되는 대로 timestamp, isActive 추가하기


## Screenshots
<img width="759" alt="스크린샷 2023-05-07 22 50 11" src="https://user-images.githubusercontent.com/98005864/236681518-9316d717-308f-4af4-b828-7d4a039252a5.png">
<img width="364" alt="스크린샷 2023-05-21 04 44 12" src="https://github.com/techeer-sv/Mindspace_backend/assets/98005864/773b94bf-f220-4c64-8844-c7d070e8ddaf">


## Test Checklist
- [x] 회원가입을 했을 때 db에 timestamp, isActive 필드가 존재하는지 + 제대로 저장이 되는지 확인하기
- [x] `./gradlew clean build` `docker compose up -d --build` 한 뒤 backend docker 로그 확인했을 때 사진과 같이 timestamp필드가 생기는 지 확인하기 