### PR TITLE
settting/swagger/21

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	implementation 'org.springdoc:springdoc-openapi-ui:1.6.9'
 
 //	mysql db 연동
 	runtimeOnly 'com.mysql:mysql-connector-j'


### PR DESCRIPTION
## Summary
스웨거 연동

## Description
- gradle 파일에 코드를 추가해 swagger 연동했습니다.

## Screenshots
![image](https://github.com/techeer-sv/Mindspace_backend/assets/105929978/f18d21b6-e4df-42df-9611-fcf6220d3d61)

## Test Checklist
- [ ] 터미널에 `./gradlew clean build` 를 입력하여 빌드 후 도커로 백엔드와 db를 실행하여 http://localhost:8080/swagger-ui/index.html 에 접속이 되는지 확인부탁드립니다.

## 주의사항
api 변경 사항 있을 시 ./gradlew clean build 하고 다시 도커를 빌드해야 변경사항이 스웨거에도 반영됩니다.