### PR TITLE
bug/corsError/18

### DIFF
--- a/src/main/java/com/mindspace/backend/global/config/WebConfig.java
+++ b/src/main/java/com/mindspace/backend/global/config/WebConfig.java
@@ -1,0 +1,17 @@
+package com.mindspace.backend.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@RequiredArgsConstructor
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("*");
+    }
+}


### PR DESCRIPTION
## Summary
CORS 해결

## Description
- global/config 폴더에 WebConfig에 모든 출처에서의 요청에 대해 허용하는 방식으로 cors 에러를 해결했습니다.

## Screenshots
<img width="448" alt="image" src="https://github.com/techeer-sv/Mindspace_backend/assets/105929978/ab07f15b-8abc-4021-960e-f6a6dea07ab5">

## 실행 전 세팅
프론트의 가장 최신 develop브렌치로 이동 후 `Mindspace/frontend`에 .env파일을 생성합니다. env파일 내용은 [노션](https://www.notion.so/dr0joon/Frontend-7e7ebe6f7f224f8c846113ce3555de21?pvs=4)에 있습니다!

`./gradlew clean build` 명령어로 빌드 후 도커를 실행합니다.

## Test Checklist
- [ ] 백엔드와 프론트 둘다 실행 후 회원가입 및 로그인 시 정상적으로 실행되는 지 확인
