### PR TITLE
Feature/foreign key/20

### DIFF
--- a/src/main/java/com/mindspace/backend/domain/board/controller/BoardController.java
+++ b/src/main/java/com/mindspace/backend/domain/board/controller/BoardController.java
@@ -49,9 +49,7 @@ public class BoardController {
     @DeleteMapping("/{id}")
     @ResponseStatus(HttpStatus.OK)
     public void deleteBoard(@PathVariable int id) {
-        BOARD_SERVICE.deleteBoard(id);{
-            BOARD_SERVICE.deleteBoard(id);
-        }
+        BOARD_SERVICE.deleteBoard(id);
     }
 
     // 게시글 수정

--- a/src/main/java/com/mindspace/backend/domain/board/controller/BoardController.java
+++ b/src/main/java/com/mindspace/backend/domain/board/controller/BoardController.java
@@ -13,6 +13,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import java.util.ArrayList;
 import java.util.List;
 
 @RestController
@@ -25,16 +26,24 @@ public class BoardController {
     // 전체 게시글 조회
     @GetMapping("/all")
     @ResponseStatus(HttpStatus.OK)
-    public List<Board> getAllBoard(){
-        return BOARD_SERVICE.getAllBoard();
+    public List<BoardResponseDto> getAllBoard(){
+        List<Board> boardlist = BOARD_SERVICE.getAllBoard();
+        List<BoardResponseDto> boardResponseList = new ArrayList<>();
+
+        for (Board board : boardlist) {
+            BoardResponseDto boardResponseDto = BOARD_MAPPER.DtoFromEntity(board);
+            boardResponseList.add(boardResponseDto);
+        }
+
+        return boardResponseList;
     }
 
     // 게시글 조회
     @GetMapping("/{id}")
     @ResponseStatus(HttpStatus.OK)
-    public ResponseEntity<Board> findOneBoard(@PathVariable int id){
+    public BoardResponseDto findOneBoard(@PathVariable int id){
         Board board = BOARD_SERVICE.findOneBoard(id);
-        return new ResponseEntity<>(board, HttpStatus.OK);
+        return BOARD_MAPPER.DtoFromEntity(board);
     }
 
     // 게시글 작성

--- a/src/main/java/com/mindspace/backend/domain/board/controller/BoardController.java
+++ b/src/main/java/com/mindspace/backend/domain/board/controller/BoardController.java
@@ -40,9 +40,9 @@ public class BoardController {
     // 게시글 작성
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public BoardResponseDto createBoard(
-            @RequestBody BoardRequestDto boardRequestDto, @RequestHeader("Authorization") int userId) {
-        return BOARD_MAPPER.DtoToEntity(boardRequestDto.builder().userId(userId).build());
+    public BoardResponseDto createBoard(@RequestBody BoardRequestDto boardRequestDto, @RequestHeader("Authorization") int userId) {
+        Board createResult = BOARD_SERVICE.createBoard(boardRequestDto, userId);
+        return BOARD_MAPPER.DtoFromEntity(createResult);
     }
 
     // 게시글 삭제

--- a/src/main/java/com/mindspace/backend/domain/board/controller/BoardController.java
+++ b/src/main/java/com/mindspace/backend/domain/board/controller/BoardController.java
@@ -42,8 +42,7 @@ public class BoardController {
     @ResponseStatus(HttpStatus.CREATED)
     public BoardResponseDto createBoard(
             @RequestBody BoardRequestDto boardRequestDto, @RequestHeader("Authorization") int userId) {
-        Board createResult = BOARD_SERVICE.createBoard(boardRequestDto, userId);
-        return BOARD_MAPPER.DtoFromEntity(createResult);
+        return BOARD_MAPPER.DtoToEntity(boardRequestDto.builder().userId(userId).build());
     }
 
     // 게시글 삭제

--- a/src/main/java/com/mindspace/backend/domain/board/controller/BoardController.java
+++ b/src/main/java/com/mindspace/backend/domain/board/controller/BoardController.java
@@ -41,8 +41,8 @@ public class BoardController {
     @PostMapping("/")
     @ResponseStatus(HttpStatus.CREATED)
     public BoardResponseDto createBoard(
-            @RequestBody BoardRequestDto boardRequestDto) {
-        Board createResult = BOARD_SERVICE.createBoard(boardRequestDto);
+            @RequestBody BoardRequestDto boardRequestDto, @RequestHeader("Authorization") int userId) {
+        Board createResult = BOARD_SERVICE.createBoard(boardRequestDto, userId);
         return BOARD_MAPPER.DtoFromEntity(createResult);
     }
 

--- a/src/main/java/com/mindspace/backend/domain/board/controller/BoardController.java
+++ b/src/main/java/com/mindspace/backend/domain/board/controller/BoardController.java
@@ -41,8 +41,8 @@ public class BoardController {
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     public BoardResponseDto createBoard(
-            @RequestBody BoardRequestDto boardRequestDto) {
-        Board createResult = BOARD_SERVICE.createBoard(boardRequestDto);
+            @RequestBody BoardRequestDto boardRequestDto, @RequestHeader("Authorization") int userId) {
+        Board createResult = BOARD_SERVICE.createBoard(boardRequestDto, userId);
         return BOARD_MAPPER.DtoFromEntity(createResult);
     }
 

--- a/src/main/java/com/mindspace/backend/domain/board/controller/BoardController.java
+++ b/src/main/java/com/mindspace/backend/domain/board/controller/BoardController.java
@@ -6,10 +6,8 @@ import com.mindspace.backend.domain.board.dto.BoardResponseDto;
 import com.mindspace.backend.domain.board.entity.Board;
 import com.mindspace.backend.domain.board.service.BoardService;
 import lombok.RequiredArgsConstructor;
-import lombok.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;

--- a/src/main/java/com/mindspace/backend/domain/board/dto/BoardMapper.java
+++ b/src/main/java/com/mindspace/backend/domain/board/dto/BoardMapper.java
@@ -1,6 +1,8 @@
 package com.mindspace.backend.domain.board.dto;
 
 import com.mindspace.backend.domain.board.entity.Board;
+import com.mindspace.backend.domain.node.entity.Node;
+import com.mindspace.backend.domain.user.entity.User;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -9,18 +11,19 @@ public class BoardMapper {
         return Board.builder()
                 .title(boardRequestDto.getTitle())
                 .content(boardRequestDto.getContent())
-                .userId(boardRequestDto.getUserId())
-                .nodeId(boardRequestDto.getNodeId())
+                .user(User.builder().id(boardRequestDto.getUserId()).build())
+                .node(Node.builder().id(boardRequestDto.getNodeId()).build())
                 .build();
     }
+
 
     public BoardResponseDto DtoFromEntity(Board board) {
         return BoardResponseDto.builder()
                 .id(board.getId())
                 .title(board.getTitle())
                 .content(board.getContent())
-                .userId(board.getUserId())
-                .nodeId(board.getNodeId())
+                .userId(board.getUser().getId())
+                .nodeId(board.getId())
                 .build();
     }
 }

--- a/src/main/java/com/mindspace/backend/domain/board/dto/BoardMapper.java
+++ b/src/main/java/com/mindspace/backend/domain/board/dto/BoardMapper.java
@@ -2,17 +2,27 @@ package com.mindspace.backend.domain.board.dto;
 
 import com.mindspace.backend.domain.board.entity.Board;
 import com.mindspace.backend.domain.node.entity.Node;
+import com.mindspace.backend.domain.node.repository.NodeRepository;
 import com.mindspace.backend.domain.user.entity.User;
+import com.mindspace.backend.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 @Component
+@RequiredArgsConstructor
 public class BoardMapper {
+    private final UserRepository USER_REPOSITORY;
+    private final NodeRepository NODE_REPOSITORY;
+
     public Board DtoToEntity(BoardRequestDto boardRequestDto) {
+        User user = USER_REPOSITORY.findById(boardRequestDto.getUserId()).orElseThrow(NullPointerException::new);
+        Node node = NODE_REPOSITORY.findById(boardRequestDto.getNodeId()).orElseThrow(NullPointerException::new);
+
         return Board.builder()
                 .title(boardRequestDto.getTitle())
                 .content(boardRequestDto.getContent())
-                .user(User.builder().id(boardRequestDto.getUserId()).build())
-                .node(Node.builder().id(boardRequestDto.getNodeId()).build())
+                .user(user)
+                .node(node)
                 .build();
     }
 
@@ -22,7 +32,7 @@ public class BoardMapper {
                 .id(board.getId())
                 .title(board.getTitle())
                 .content(board.getContent())
-                .userId(board.getUser().getId())
+                .userNickname(board.getUser().getNickname())
                 .nodeId(board.getNode().getId())
                 .build();
     }

--- a/src/main/java/com/mindspace/backend/domain/board/dto/BoardRequestDto.java
+++ b/src/main/java/com/mindspace/backend/domain/board/dto/BoardRequestDto.java
@@ -4,9 +4,9 @@ import com.sun.istack.NotNull;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.experimental.Accessors;
 
 @Getter
-@Setter
 @Builder
 public class BoardRequestDto {
 
@@ -17,9 +17,40 @@ public class BoardRequestDto {
     @NotNull
     private String content;
 
-   @NotNull
+    @NotNull
     private int userId;
 
     @NotNull
     private int nodeId;
+
+    public static class BoardRequestDtoBuilder {
+        public BoardRequestDtoBuilder userId(int userId) {
+            this.userId = userId;
+            return this;
+        }
+    }
+//    public static class Builder {
+//        private int userId;
+//        // 다른 필드들...
+//
+//        public Builder userId(int userId) {
+//            this.userId = userId;
+//            return this;
+//        }
+//
+//        // 다른 필드들의 빌더 메서드들...
+//
+//        public BoardRequestDto build() {
+//            return new BoardRequestDto(this);
+//        }
+//    }
+//
+//    private BoardRequestDto(Builder builder) {
+//        this.userId = builder.userId;
+//        // 다른 필드들...
+//    }
+//
+//    public static Builder builder() {
+//        return new Builder();
+//    }
 }

--- a/src/main/java/com/mindspace/backend/domain/board/dto/BoardRequestDto.java
+++ b/src/main/java/com/mindspace/backend/domain/board/dto/BoardRequestDto.java
@@ -1,5 +1,7 @@
 package com.mindspace.backend.domain.board.dto;
 
+import com.mindspace.backend.domain.node.entity.Node;
+import com.mindspace.backend.domain.user.entity.User;
 import com.sun.istack.NotNull;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/mindspace/backend/domain/board/dto/BoardRequestDto.java
+++ b/src/main/java/com/mindspace/backend/domain/board/dto/BoardRequestDto.java
@@ -1,12 +1,8 @@
 package com.mindspace.backend.domain.board.dto;
 
-import com.mindspace.backend.domain.node.entity.Node;
-import com.mindspace.backend.domain.user.entity.User;
 import com.sun.istack.NotNull;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
-import lombok.experimental.Accessors;
 
 @Getter
 @Builder

--- a/src/main/java/com/mindspace/backend/domain/board/dto/BoardRequestDto.java
+++ b/src/main/java/com/mindspace/backend/domain/board/dto/BoardRequestDto.java
@@ -3,8 +3,10 @@ package com.mindspace.backend.domain.board.dto;
 import com.sun.istack.NotNull;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
 
 @Getter
+@Setter
 @Builder
 public class BoardRequestDto {
 
@@ -15,7 +17,7 @@ public class BoardRequestDto {
     @NotNull
     private String content;
 
-    @NotNull
+   @NotNull
     private int userId;
 
     @NotNull

--- a/src/main/java/com/mindspace/backend/domain/board/dto/BoardRequestDto.java
+++ b/src/main/java/com/mindspace/backend/domain/board/dto/BoardRequestDto.java
@@ -23,6 +23,9 @@ public class BoardRequestDto {
     @NotNull
     private int nodeId;
 
+    public void setUserId(int userId) {
+    }
+
     public static class BoardRequestDtoBuilder {
         public BoardRequestDtoBuilder userId(int userId) {
             this.userId = userId;

--- a/src/main/java/com/mindspace/backend/domain/board/dto/BoardRequestDto.java
+++ b/src/main/java/com/mindspace/backend/domain/board/dto/BoardRequestDto.java
@@ -18,13 +18,17 @@ public class BoardRequestDto {
     private String content;
 
     @NotNull
-    private int userId;
+    private int userId; // int 타입의 필드는 기본적으로 null이 아닌 값을 가지므로 @NotNull 어노테이션은 필요하지 않음
 
     @NotNull
     private int nodeId;
 
-    public void setUserId(int userId) {
-    }
+//    public void setUserId(int userId){
+//    }
+
+//    public void setNodeId(int nodeId) {
+//        this.nodeId = nodeId;
+//    }
 
     public static class BoardRequestDtoBuilder {
         public BoardRequestDtoBuilder userId(int userId) {
@@ -32,28 +36,4 @@ public class BoardRequestDto {
             return this;
         }
     }
-//    public static class Builder {
-//        private int userId;
-//        // 다른 필드들...
-//
-//        public Builder userId(int userId) {
-//            this.userId = userId;
-//            return this;
-//        }
-//
-//        // 다른 필드들의 빌더 메서드들...
-//
-//        public BoardRequestDto build() {
-//            return new BoardRequestDto(this);
-//        }
-//    }
-//
-//    private BoardRequestDto(Builder builder) {
-//        this.userId = builder.userId;
-//        // 다른 필드들...
-//    }
-//
-//    public static Builder builder() {
-//        return new Builder();
-//    }
 }

--- a/src/main/java/com/mindspace/backend/domain/board/dto/BoardResponseDto.java
+++ b/src/main/java/com/mindspace/backend/domain/board/dto/BoardResponseDto.java
@@ -15,7 +15,7 @@ public class BoardResponseDto {
 
     private String content;
 
-    private int userId;
+    private String userNickname;
 
     private int nodeId;
 }

--- a/src/main/java/com/mindspace/backend/domain/board/entity/Board.java
+++ b/src/main/java/com/mindspace/backend/domain/board/entity/Board.java
@@ -27,7 +27,7 @@ public class Board extends Timestamp {
     private String content;
 
     @OneToOne
-    @JoinColumn(name="user_id", referencedColumnName = "member_id")
+    @JoinColumn(name="user_id", referencedColumnName = "user_id")
     private User user;
 
     @ManyToOne

--- a/src/main/java/com/mindspace/backend/domain/board/entity/Board.java
+++ b/src/main/java/com/mindspace/backend/domain/board/entity/Board.java
@@ -1,6 +1,8 @@
 package com.mindspace.backend.domain.board.entity;
 
 import com.mindspace.backend.domain.board.dto.BoardRequestDto;
+import com.mindspace.backend.domain.node.entity.Node;
+import com.mindspace.backend.domain.user.entity.User;
 import lombok.*;
 
 import javax.persistence.*;
@@ -16,17 +18,20 @@ public class Board {
     @GeneratedValue(strategy = GenerationType.AUTO)
     @Column(name = "board_id")
     private int id;
+
     @Column(name="title", nullable = false)
     private String title;
+
     @Column(name="content", nullable = false)
     private String content;
-    @Column(name="user_id", nullable = false)
-    private int userId;
-    @Column(name="node_id", nullable = false)
-    private int nodeId;
 
-    public static void delete() {
-    }
+    @OneToOne
+    @JoinColumn(name="user_id", referencedColumnName = "member_id")
+    private User user;
+
+    @ManyToOne
+    @JoinColumn(name = "node_id", referencedColumnName = "node_id")
+    private Node node;
 
     public void update(BoardRequestDto boardUpdate) {
         this.title = boardUpdate.getTitle();

--- a/src/main/java/com/mindspace/backend/domain/board/service/BoardService.java
+++ b/src/main/java/com/mindspace/backend/domain/board/service/BoardService.java
@@ -7,7 +7,6 @@ import com.mindspace.backend.domain.board.repository.BoardRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import javax.transaction.Transactional;
 import java.util.List;
 
 @Service

--- a/src/main/java/com/mindspace/backend/domain/board/service/BoardService.java
+++ b/src/main/java/com/mindspace/backend/domain/board/service/BoardService.java
@@ -21,8 +21,14 @@ public class BoardService {
     }
 
     public Board createBoard(BoardRequestDto boardRequestDto, int userId) {
-        boardRequestDto.setUserId(userId);
-        return BOARD_REPOSITORY.save(BOARD_MAPPER.DtoToEntity(boardRequestDto));
+        BoardRequestDto updatedDto = BoardRequestDto.builder()
+                .title(boardRequestDto.getTitle())
+                .content(boardRequestDto.getContent())
+                .userId(userId)
+                .nodeId(boardRequestDto.getNodeId())
+                .build();
+
+        return BOARD_REPOSITORY.save(BOARD_MAPPER.DtoToEntity(updatedDto));
     }
 
 //    public Board createBoard(BoardRequestDto boardRequestDto, int userId) {

--- a/src/main/java/com/mindspace/backend/domain/board/service/BoardService.java
+++ b/src/main/java/com/mindspace/backend/domain/board/service/BoardService.java
@@ -20,7 +20,8 @@ public class BoardService {
         return BOARD_REPOSITORY.findAll();
     }
 
-    public Board createBoard(BoardRequestDto boardRequestDto) {
+    public Board createBoard(BoardRequestDto boardRequestDto, int userId) {
+        boardRequestDto.setUserId(userId);
         return BOARD_REPOSITORY.save(BOARD_MAPPER.DtoToEntity(boardRequestDto));
     }
 

--- a/src/main/java/com/mindspace/backend/domain/board/service/BoardService.java
+++ b/src/main/java/com/mindspace/backend/domain/board/service/BoardService.java
@@ -25,6 +25,15 @@ public class BoardService {
         return BOARD_REPOSITORY.save(BOARD_MAPPER.DtoToEntity(boardRequestDto));
     }
 
+//    public Board createBoard(BoardRequestDto boardRequestDto, int userId) {
+//        BoardRequestDto dtoWithUserId = boardRequestDto.toBuilder().userId(userId).build();
+//        return BOARD_REPOSITORY.save(BOARD_MAPPER.DtoToEntity(dtoWithUserId));
+//    }
+
+//    public Board createBoard(BoardRequestDto boardRequestDto, int userId) {
+//        return BOARD_REPOSITORY.save(boardRequestDto.toBuilder().userId(userId).build());
+//    }
+
     public void deleteBoard(int id) {
         Board board = IsBoardExisted(id);
         BOARD_REPOSITORY.deleteById(board.getId());

--- a/src/main/java/com/mindspace/backend/domain/node/entity/Node.java
+++ b/src/main/java/com/mindspace/backend/domain/node/entity/Node.java
@@ -1,11 +1,13 @@
 package com.mindspace.backend.domain.node.entity;
 
+import com.mindspace.backend.domain.board.entity.Board;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import java.util.List;
 
 @Entity
 @Getter
@@ -21,4 +23,7 @@ public class Node {
 
     @Column(name= "node_name", nullable = false)
     private String name;
+
+    @OneToMany(mappedBy = "node")
+    private List<Board> boards;
 }


### PR DESCRIPTION
## Summary
Header에 userid 값 넣기, 외래키 매핑

## Description
- 게시글 작성 api에서 userid 값 Header로 분리
- board - node(일대다 관계), board - user(일대일 관계) 외래키 매핑
- board CRUD 가 정상적으로 동작하는지 확인

## Screenshots
![스크린샷 2023-05-23 오전 2 18 37](https://github.com/techeer-sv/Mindspace_backend/assets/98696925/87355556-2289-45fa-8874-c9ee1e8611aa)
---------------------------------------------------------------------------------------------------------------------
![스크린샷 2023-05-23 오전 2 19 50](https://github.com/techeer-sv/Mindspace_backend/assets/98696925/0f5a68a0-f01d-4176-8b9c-63c27fcb458b)
![스크린샷 2023-05-23 오전 2 25 24](https://github.com/techeer-sv/Mindspace_backend/assets/98696925/0645b6bc-5790-4f6f-a14f-4f62263a616d)
---------------------------------------------------------------------------------------------------------------------
![스크린샷 2023-05-23 오전 2 23 06](https://github.com/techeer-sv/Mindspace_backend/assets/98696925/d48a9923-7830-4e84-83e8-a188da421571)
---------------------------------------------------------------------------------------------------------------------
![스크린샷 2023-05-23 오전 2 22 41](https://github.com/techeer-sv/Mindspace_backend/assets/98696925/48909a96-be36-4a89-8328-e6d690f5ed62)
---------------------------------------------------------------------------------------------------------------------
![스크린샷 2023-05-23 오전 2 23 40](https://github.com/techeer-sv/Mindspace_backend/assets/98696925/781929e2-d052-41ef-9ef2-474f96ccf615)
---------------------------------------------------------------------------------------------------------------------
![스크린샷 2023-05-23 오전 2 24 18](https://github.com/techeer-sv/Mindspace_backend/assets/98696925/4d03d9ab-0867-40cb-9366-f49ed8de13c8)
## Test Checklist
- [x] (스크린샷1) 회원가입, 로그인 후 데이터베이스에 node_id 값을 넣는다. 
- [x] (스크린샷2, 3) Headers에 값(userId)을 넣고 게시글 작성을 한다.
- [x] (스크린샷4) 전체 게시글 조회를 한다.
- [x] (스크린샷5) 특정 게시글 하나를 조회한다.
- [x] (스크린샷6) 게시글 수정을 한다.
- [x] (스크린샷7) 게시글 삭제를 한다.